### PR TITLE
Adapt access modifier for initBars

### DIFF
--- a/speechrecognitionview/src/main/java/com/github/zagum/speechrecognitionview/RecognitionProgressView.java
+++ b/speechrecognitionview/src/main/java/com/github/zagum/speechrecognitionview/RecognitionProgressView.java
@@ -259,7 +259,7 @@ public class RecognitionProgressView extends View implements RecognitionListener
         }
     }
 
-    private void initBars() {
+    protected void initBars() {
         final List<Integer> heights = initBarHeights();
         int firstCirclePosition = getMeasuredWidth() / 2 -
                 2 * spacing -


### PR DESCRIPTION
private -> protected

This allows subclasses to define a different drawing
behavior, e.g. to draw the middle circle first